### PR TITLE
Cleanup and Simplify.

### DIFF
--- a/src/collective/folderishtraverse/browser/configure.zcml
+++ b/src/collective/folderishtraverse/browser/configure.zcml
@@ -1,22 +1,21 @@
 <configure
-    i18n_domain="collective.folderishtraverse"
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:i18n="http://namespaces.zope.org/i18n">
+    xmlns:browser="http://namespaces.zope.org/browser">
+
   <browser:page
       class=".traverse_view.TraverseView"
       for="plone.folder.interfaces.IFolder"
-      i18n:domain="plone"
       layer="collective.folderishtraverse.interfaces.ICollectiveFolderishtraverseLayer"
       name="traverse_view"
       permission="zope2.View"
   />
+
   <browser:page
       class=".traverse_view.TraverseView"
       for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
-      i18n:domain="plone"
       layer="collective.folderishtraverse.interfaces.ICollectiveFolderishtraverseLayer"
       name="traverse_view"
       permission="zope2.View"
   />
+
 </configure>

--- a/src/collective/folderishtraverse/browser/traverse_view.py
+++ b/src/collective/folderishtraverse/browser/traverse_view.py
@@ -1,126 +1,65 @@
 # -*- coding: utf-8 -*-
 from AccessControl import getSecurityManager
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import utils
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.Five.browser import BrowserView
-from Products.statusmessages.interfaces import IStatusMessage
 from plone.folder.interfaces import IFolder
 from zExceptions import Redirect
-from zope.i18nmessageid import MessageFactory
-
-try:
-    from Products.LinguaPlone.interfaces import ITranslatable
-    LINGUA_PLONE_INSTALLED = True
-except ImportError:
-    LINGUA_PLONE_INSTALLED = False
-try:
-    import plone.app.contenttypes  # noqa
-    PAC_INSTALLED = True
-except ImportError:
-    PAC_INSTALLED = False
 
 
-_ = MessageFactory('collective.folderishtraverse')
-
-
-# XXX: maybe make this a registry entry?
-NON_TRAVERSE_FALLBACK_VIEW = 'folder_summary_view'
-if PAC_INSTALLED:
-    NON_TRAVERSE_FALLBACK_VIEW = '@@summary_view'
-
-EDITOR_PERMISSION = 'Add portal content'
+NON_TRAVERSE_FALLBACK_VIEW = '@@summary_view'
 VIEW_PERMISSION = 'View'
-
-
-# Let editors also traverse to the traversee and do not just show the folder contents view.
-# See below in code, where it is used.
-EDITOR_TRAVERSE = True
 
 
 class TraverseView(BrowserView):
 
-    def permitted(self, context=None, permission=EDITOR_PERMISSION):
+    def permitted(self, context=None, permission=VIEW_PERMISSION):
         if not context:
             context = self.context
         sm = getSecurityManager()
         return sm.checkPermission(permission, context)
 
-    def find_endpoint(self, obj, lang, types_to_list):
+    def find_redirection_target(self, obj, types_to_list):
         if not (
             IFolder.providedBy(obj) or IPloneSiteRoot.providedBy(obj)
         ):
             return obj
+
         contents = obj.contentIds()
-        # TODO: make list reversable
+
         for cid in contents:
             child = obj[cid]
-            # try to get translation if LinguaPlone is installed, child
-            # is translatable and child language does not match lang
-            if LINGUA_PLONE_INSTALLED:
-                if ITranslatable.providedBy(child):
-                    child_lang = child.Language()
-                    # child lang can be empty string, only try to
-                    # translate if explicit lang
-                    if child_lang and child_lang != lang:
-                        translation = child.getTranslation(lang)
-                        if not translation:
-                            continue  # ...with next obj in folder
-                        child = translation
-            # only traverse to allowed objects
-            allowed = self.permitted(
-                context=child,
-                permission=VIEW_PERMISSION
-            )
-            if not allowed:
+
+            # Only traverse to allowed objects
+            if not self.permitted(context=child):
                 continue
-            # only traverse to objects listed in typesToList
+
+            # Only traverse to objects listed in typesToList
             if child.portal_type not in types_to_list:
                 continue
-            # we've found a published object, which can be used as
-            # possible endpoint, except it has 'traverse_view' enabled
+
+            # We've found a published object, which can be used as possible
+            # redirection target.
             obj = child
+
+            # ... except it has 'traverse_view' enabled
             if child.defaultView() == 'traverse_view':
-                obj = self.find_endpoint(child, lang, types_to_list)
+                obj = self.find_redirection_target(child, types_to_list)
+
             break
         return obj
 
-    def __call__(self, *args, **kwargs):
-        ctx = self.context
-        url = None
+    def __call__(self):
 
-        if EDITOR_TRAVERSE or not self.permitted():
-            # Traverse to the traversee.
-            # This is the standard case.
-            # I think the other case should in fact be gone, but then we might
-            # loose this nice secuirty guard: If the new context is still a
-            # traverse_view the traversal might have gone wrong and we use the
-            # folder summary view on the starting context.
-            # So the code block further down checking for the new context still
-            # being a "traverse_view" is cool and should stay.
-            types_to_list = utils.typesToList(ctx)
-            plt = getToolByName(self.context, 'portal_languages')
-            pref_lang = plt.getPreferredLanguage()
-            ctx = self.find_endpoint(ctx, pref_lang, types_to_list)
-        url = ctx.absolute_url()
+        # Find redirection target.
+        context = self.context
+        types_to_list = utils.typesToList(context)
+        context = self.find_redirection_target(context, types_to_list)
+        url = context.absolute_url()
 
-        # What? The new context still having traverse_view enabled? Shouldn't happen.
-        # Except this `EDITOR_TRAVERSE` flag set to `False`.
-        if ctx.defaultView() == 'traverse_view':
-            if not self.permitted(context=ctx):
-                # What? I cannot edit the traversee?
-                # OK, let"s use the fallback view.
-                url = '%s/%s' % (url, NON_TRAVERSE_FALLBACK_VIEW)
-            else:
-                # List folder contents permitted. Show folder_contents.
-                url = '%s/folder_contents' % url
-                messages = IStatusMessage(self.request)
-                messages.addStatusMessage(
-                    _("traverse_view-statusmessage",
-                      u"""This is a traverse view. Users who are not allowed to
-                          see the folder listing are redirected to the first
-                          subitem in this directory."""),
-                    type="info")
+        # Fallback - e.g. no valid context found or no items in folder.
+        if context.defaultView() == 'traverse_view':
+            url = '%s/%s' % (url, NON_TRAVERSE_FALLBACK_VIEW)
 
         self.request.response.setHeader("Location", url)
         self.request.response.setStatus(302)


### PR DESCRIPTION
Remove some old cases which are not needed anymore:

- LinguaPlone support (no language support at all anymore - p.a.multilingual as well as collective.multilingual have root-language folders where we shouldn't come to redirect to wrong languages anymore. Also, it's also a bit of an editors problem, if there should be a incorrectly translated language. However, I'm not 100% sure about this simplification - maybe we should re-include modern multilingual support...)

- Editors are also redirected to a content item and not be redirected to the folder contents view. That's a much simpler concept and I think there is no need anymore for redirection to folder contents. Or not?